### PR TITLE
Install config gem and add settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in config_rbs_generator.gemspec
 gemspec
 
+gem 'config'
 gem 'minitest'
 gem 'rake', '~> 13.0'
 gem 'rubocop', '~> 1.21'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,42 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    concurrent-ruby (1.1.10)
+    config (4.0.0)
+      deep_merge (~> 1.2, >= 1.2.1)
+      dry-validation (~> 1.0, >= 1.0.0)
+    deep_merge (1.2.2)
+    dry-configurable (0.15.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.6)
+    dry-container (0.10.1)
+      concurrent-ruby (~> 1.0)
+    dry-core (0.8.1)
+      concurrent-ruby (~> 1.0)
+    dry-inflector (0.3.0)
+    dry-initializer (3.1.1)
+    dry-logic (1.2.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.5, >= 0.5)
+    dry-schema (1.9.3)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.13, >= 0.13.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-initializer (~> 3.0)
+      dry-logic (~> 1.0)
+      dry-types (~> 1.5)
+    dry-types (1.5.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.5, >= 0.5)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
+    dry-validation (1.8.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.7, >= 0.7.1)
+      dry-core (~> 0.5, >= 0.5)
+      dry-initializer (~> 3.0)
+      dry-schema (~> 1.8, >= 1.8.0)
     json (2.6.2)
     minitest (5.16.2)
     parallel (1.22.1)
@@ -36,6 +72,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  config
   config_rbs_generator!
   minitest
   rake (~> 13.0)

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'config'
+
+Config.setup do |config|
+  config.const_name = 'Settings'
+  config.load_and_set_settings('config/settings.yml')
+end


### PR DESCRIPTION
The config gem was installed for use in testing the type definitions generated by the generator, etc.
Also, added configuration to make config gem available in plain Ruby.