### PR TITLE
Generate type definitions from one paragraph of Settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ AllCops:
   TargetRubyVersion: 3.1
   SuggestExtensions: false
 
+Style/Documentation:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: true
 

--- a/bin/config_rbs_generate
+++ b/bin/config_rbs_generate
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/config_rbs_generator'
+
+puts '== generate started... =='
+puts ConfigRbsGenerator.run
+puts 'Settings RBS generated!'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,2 @@
+size: 2
+text: How are you?

--- a/lib/config_rbs_generator.rb
+++ b/lib/config_rbs_generator.rb
@@ -1,8 +1,35 @@
 # frozen_string_literal: true
 
 require_relative 'config_rbs_generator/version'
+require_relative '../config/initializers/config'
 
 module ConfigRbsGenerator
+  def self.run
+    outputs = Outputs.new
+
+    Settings.each do |setting|
+      outputs.add_method_definition(setting)
+    end
+
+    outputs.finalize
+    outputs.text
+  end
+
+  class Outputs
+    attr_reader :text
+
+    def initialize
+      @text = "class #{Config.const_name}\n"
+    end
+
+    def add_method_definition(setting)
+      @text += "  def #{setting[0]}: () -> #{setting[1].class}\n"
+    end
+
+    def finalize
+      @text += "end\n"
+    end
+  end
+
   class Error < StandardError; end
-  # Your code goes here...
 end

--- a/sig/config_rbs_generator.rbs
+++ b/sig/config_rbs_generator.rbs
@@ -1,4 +1,15 @@
 module ConfigRbsGenerator
   VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+
+  def self.run: () -> String
+
+  class Outputs
+    @text: String
+
+    attr_reader text: ::String
+
+    def initialize: () -> void
+    def add_method_definition: ([::Symbol, (::String | ::Integer)] setting) -> ::String
+    def finalize: -> ::String
+  end
 end

--- a/test/test_config_rbs_generator.rb
+++ b/test/test_config_rbs_generator.rb
@@ -2,8 +2,19 @@
 
 require_relative 'test_helper'
 
-class TestConfigRbsGenerator < Minitest::Test
-  def test_that_it_has_a_version_number
+describe ConfigRbsGenerator do
+  it 'has a version number' do
     refute_nil ::ConfigRbsGenerator::VERSION
+  end
+
+  describe '.run' do
+    it 'covers all settings' do
+      assert_equal <<~SETTINGS, ConfigRbsGenerator.run
+        class Settings
+          def size: () -> Integer
+          def text: () -> String
+        end
+      SETTINGS
+    end
   end
 end

--- a/test/test_outputs.rb
+++ b/test/test_outputs.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+describe ConfigRbsGenerator::Outputs do
+  describe '#add_method_definition' do
+    def setup
+      @outputs = ConfigRbsGenerator::Outputs.new
+      @setting = [:hello, 'Hello World!']
+    end
+
+    it 'added "def hello: () -> String" at the end line' do
+      assert_equal <<~TEXT, @outputs.add_method_definition(@setting)
+        class Settings
+          def hello: () -> String
+      TEXT
+    end
+  end
+
+  describe '#finalize' do
+    def setup
+      @outputs = ConfigRbsGenerator::Outputs.new
+    end
+
+    it 'added "end" at the end line' do
+      assert_equal <<~TEXT, @outputs.finalize
+        class Settings
+        end
+      TEXT
+    end
+  end
+end


### PR DESCRIPTION
### Add `bin/config_rbs_generate` command

Type definitions are now output to the console when the `bin/config_rbs_generate` command is executed.
The generated type definitions are only output to the console, but we will generate RBS files in the future.

### Support for type definition of Settings for one paragraph

Supported cases are:

```yaml
size: 2  #=> def size: () -> Integer
text: How are you?  #=> def text: () -> String
```

Cases with one paragraph but `Array` or more than two paragraphs are not yet supported.

```yaml
array:
  - 10
  - Nice to meet you!
  - Goodbye.
section:
  size: 3
```