### PR TITLE
Support for type definition when the element of setting is an Array

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ AllCops:
   TargetRubyVersion: 3.1
   SuggestExtensions: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,2 +1,6 @@
 size: 2
 text: How are you?
+array:
+  - 10
+  - Nice to meet you!
+  - Goodbye.

--- a/lib/config_rbs_generator.rb
+++ b/lib/config_rbs_generator.rb
@@ -23,7 +23,15 @@ module ConfigRbsGenerator
     end
 
     def add_method_definition(setting)
-      @text += "  def #{setting[0]}: () -> #{setting[1].class}\n"
+      @text += "  def #{setting[0]}: () -> "
+
+      if setting[1].instance_of?(Array)
+        klasses = setting[1].map(&:class)
+        klasses.uniq!
+        @text += "Array[#{klasses.join(' | ')}]\n"
+      else
+        @text += "#{setting[1].class}\n"
+      end
     end
 
     def finalize

--- a/sig/config_rbs_generator.rbs
+++ b/sig/config_rbs_generator.rbs
@@ -9,7 +9,7 @@ module ConfigRbsGenerator
     attr_reader text: ::String
 
     def initialize: () -> void
-    def add_method_definition: ([::Symbol, (::String | ::Integer)] setting) -> ::String
+    def add_method_definition: ([::Symbol, (::String | ::Integer | ::Array[::String | ::Integer])] setting) -> ::String
     def finalize: -> ::String
   end
 end

--- a/test/test_config_rbs_generator.rb
+++ b/test/test_config_rbs_generator.rb
@@ -13,6 +13,7 @@ describe ConfigRbsGenerator do
         class Settings
           def size: () -> Integer
           def text: () -> String
+          def array: () -> Array[Integer | String]
         end
       SETTINGS
     end

--- a/test/test_outputs.rb
+++ b/test/test_outputs.rb
@@ -15,6 +15,20 @@ describe ConfigRbsGenerator::Outputs do
           def hello: () -> String
       TEXT
     end
+
+    describe 'case of the second element of setting is Array' do
+      def setup
+        @outputs = ConfigRbsGenerator::Outputs.new
+        @setting = [:profile, ['Alice', 23, 'running']]
+      end
+
+      it 'added "def profile: () -> Array[String | Integer]" at the end line' do
+        assert_equal <<~TEXT, @outputs.add_method_definition(@setting)
+          class Settings
+            def profile: () -> Array[String | Integer]
+        TEXT
+      end
+    end
   end
 
   describe '#finalize' do


### PR DESCRIPTION
Suppose we have a setting object that contains the following Array elements:

```yaml
array:
  - 10
  - Nice to meet you!
  - Goodbye.
```

In this case, the type definition could not be generated correctly.

This PR will ensure that type definitions are generated correctly in such cases.

```yaml
# before
def profile: () -> Array

# after
def profile: () -> Array[Integer | String]
```