### PR TITLE
Fix incorrect type definitions were generated

### DIFF
--- a/lib/config_rbs_generator.rb
+++ b/lib/config_rbs_generator.rb
@@ -19,11 +19,11 @@ module ConfigRbsGenerator
     attr_reader :text
 
     def initialize
-      @text = "class #{Config.const_name}\n"
+      @text = "module #{Config.const_name}\n"
     end
 
     def add_method_definition(setting)
-      @text += "  def #{setting[0]}: () -> "
+      @text += "  def self.#{setting[0]}: () -> "
 
       if setting[1].instance_of?(Array)
         klasses = setting[1].map(&:class)

--- a/test/test_config_rbs_generator.rb
+++ b/test/test_config_rbs_generator.rb
@@ -10,10 +10,10 @@ describe ConfigRbsGenerator do
   describe '.run' do
     it 'covers all settings' do
       assert_equal <<~SETTINGS, ConfigRbsGenerator.run
-        class Settings
-          def size: () -> Integer
-          def text: () -> String
-          def array: () -> Array[Integer | String]
+        module Settings
+          def self.size: () -> Integer
+          def self.text: () -> String
+          def self.array: () -> Array[Integer | String]
         end
       SETTINGS
     end

--- a/test/test_outputs.rb
+++ b/test/test_outputs.rb
@@ -11,8 +11,8 @@ describe ConfigRbsGenerator::Outputs do
 
     it 'added "def hello: () -> String" at the end line' do
       assert_equal <<~TEXT, @outputs.add_method_definition(@setting)
-        class Settings
-          def hello: () -> String
+        module Settings
+          def self.hello: () -> String
       TEXT
     end
 
@@ -24,8 +24,8 @@ describe ConfigRbsGenerator::Outputs do
 
       it 'added "def profile: () -> Array[String | Integer]" at the end line' do
         assert_equal <<~TEXT, @outputs.add_method_definition(@setting)
-          class Settings
-            def profile: () -> Array[String | Integer]
+          module Settings
+            def self.profile: () -> Array[String | Integer]
         TEXT
       end
     end
@@ -38,7 +38,7 @@ describe ConfigRbsGenerator::Outputs do
 
     it 'added "end" at the end line' do
       assert_equal <<~TEXT, @outputs.finalize
-        class Settings
+        module Settings
         end
       TEXT
     end


### PR DESCRIPTION
- Define `Settings` instances as module.
- Define methods as singleton methods.

```
# before
class Settings
  def hello: () -> String
end

# after
module Settings
  def self.hello: () -> String
end
```

Since `Settings` is not initialized, there is no need for it to be a class.
Because methods are used with `Settings.METHOD`, it is appropriate to define them as singleton methods.