### PR TITLE
Generate type definitions from two or more paragraphs of Settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,12 @@ AllCops:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/MethodLength:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,3 +4,12 @@ array:
   - 10
   - Nice to meet you!
   - Goodbye.
+section:
+  size: 3
+  text: Hello World!
+  yeah:
+    mettya:
+      holiday: Sunday
+  paragraph:
+    - paragraph1
+    - paragraph2

--- a/lib/config_rbs_generator.rb
+++ b/lib/config_rbs_generator.rb
@@ -25,9 +25,12 @@ module ConfigRbsGenerator
     def add_method_definition(setting)
       @text += "  def self.#{setting[0]}: () -> "
 
-      if setting[1].instance_of?(Array)
-        klasses = setting[1].map(&:class)
-        klasses.uniq!
+      if setting[1].instance_of?(Config::Options)
+        @text += "self\n"
+        setting[1].each { |s| add_method_definition(s) }
+        @text
+      elsif setting[1].instance_of?(Array)
+        klasses = setting[1].map(&:class).uniq
         @text += "Array[#{klasses.join(' | ')}]\n"
       else
         @text += "#{setting[1].class}\n"

--- a/sig/config_rbs_generator.rbs
+++ b/sig/config_rbs_generator.rbs
@@ -9,7 +9,10 @@ module ConfigRbsGenerator
     attr_reader text: ::String
 
     def initialize: () -> void
-    def add_method_definition: ([::Symbol, (::String | ::Integer | ::Array[::String | ::Integer])] setting) -> ::String
+    def add_method_definition: ([::Symbol, ::String]
+                              | [::Symbol, ::Integer]
+                              | [::Symbol, ::Array[::String | ::Integer]]
+                              | [::Symbol, Config::Options] setting) -> ::String
     def finalize: -> ::String
   end
 end

--- a/test/test_config_rbs_generator.rb
+++ b/test/test_config_rbs_generator.rb
@@ -14,6 +14,13 @@ describe ConfigRbsGenerator do
           def self.size: () -> Integer
           def self.text: () -> String
           def self.array: () -> Array[Integer | String]
+          def self.section: () -> self
+          def self.size: () -> Integer
+          def self.text: () -> String
+          def self.yeah: () -> self
+          def self.mettya: () -> self
+          def self.holiday: () -> String
+          def self.paragraph: () -> Array[String]
         end
       SETTINGS
     end

--- a/test/test_outputs.rb
+++ b/test/test_outputs.rb
@@ -29,6 +29,29 @@ describe ConfigRbsGenerator::Outputs do
         TEXT
       end
     end
+
+    describe 'case of the second element of setting is Config::Options' do
+      def setup
+        @outputs = ConfigRbsGenerator::Outputs.new
+        @setting =
+          Settings.map.with_index { |s, i|
+            s if i == 3
+          }.compact.first
+      end
+
+      it 'section becomes self and its child elements are also generated' do
+        assert_equal <<~TEXT, @outputs.add_method_definition(@setting)
+          module Settings
+            def self.section: () -> self
+            def self.size: () -> Integer
+            def self.text: () -> String
+            def self.yeah: () -> self
+            def self.mettya: () -> self
+            def self.holiday: () -> String
+            def self.paragraph: () -> Array[String]
+        TEXT
+      end
+    end
   end
 
   describe '#finalize' do


### PR DESCRIPTION
We could not generate correctly from `settings.yml` which has the following paragraph:
```
# config/settings.yml

section:
  size: 3
  text: Hello World!
  yeah:
    mettya:
      holiday: Sunday
  paragraph:
    - paragraph1
    - paragraph2
```

This PR addresses that issue and ensures that type definitions are output correctly even if there are paragraphs.

```
module Settings
  def self.section: () -> self
  def self.size: () -> Integer
  def self.text: () -> String
  def self.yeah: () -> self
  def self.mettya: () -> self
  def self.holiday: () -> String
  def self.paragraph: () -> Array[String]
end
```