### PR TITLE
Do not run CI when the `Ci skip` label is present

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby:
           - '3.1.2'
-    if: contains(github.event.pull_request.labels.*.name, 'CI skip')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI skip') }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         ruby:
           - '3.1.2'
+    if: github.event.label.name != 'CI skip'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby:
           - '3.1.2'
-    if: github.event.label.name != 'CI skip'
+    if: contains(github.event.pull_request.labels.*.name, 'CI skip')
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
If we open a PR that doesn't require CI to be run, label it `CI skip` to prevent CI from being run.