### PR TITLE
Do not run CI(test) when the Ci skip label is present

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         ruby:
           - '3.1.2'
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI skip') }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
If we open a PR that doesn't require CI to be run, label it `CI skip` to prevent CI(test) from being run.