### PR TITLE
Support for Array with a `Config::Options` instance in the element

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,13 @@ section:
   paragraph:
     - paragraph1
     - paragraph2
+uho:
+  - name: name1
+    title: title1
+    body: body1
+  - name: name2
+    title: title2
+    body: body2
+  - name: name3
+    title: title3
+    body: body3

--- a/lib/config_rbs_generator.rb
+++ b/lib/config_rbs_generator.rb
@@ -30,8 +30,7 @@ module ConfigRbsGenerator
         setting[1].each { |s| add_method_definition(s) }
         @text
       elsif setting[1].instance_of?(Array)
-        klasses = setting[1].map(&:class).uniq
-        @text += "Array[#{klasses.join(' | ')}]\n"
+        convert_array_types(setting[1])
       else
         @text += "#{setting[1].class}\n"
       end
@@ -39,6 +38,17 @@ module ConfigRbsGenerator
 
     def finalize
       @text += "end\n"
+    end
+
+    private
+
+    def convert_array_types(array)
+      if array.map { |s| s.instance_of?(Config::Options) }.include?(true)
+        @text += "Array[untyped]\n"
+      else
+        klasses = array.map(&:class).uniq
+        @text += "Array[#{klasses.join(' | ')}]\n"
+      end
     end
   end
 

--- a/test/test_config_rbs_generator.rb
+++ b/test/test_config_rbs_generator.rb
@@ -21,6 +21,7 @@ describe ConfigRbsGenerator do
           def self.mettya: () -> self
           def self.holiday: () -> String
           def self.paragraph: () -> Array[String]
+          def self.uho: () -> Array[untyped]
         end
       SETTINGS
     end

--- a/test/test_outputs.rb
+++ b/test/test_outputs.rb
@@ -52,6 +52,23 @@ describe ConfigRbsGenerator::Outputs do
         TEXT
       end
     end
+
+    describe 'case of Array whose elements are Config::Options instances' do
+      def setup
+        @outputs = ConfigRbsGenerator::Outputs.new
+        @setting =
+          Settings.map.with_index { |s, i|
+            s if i == 4
+          }.compact.first
+      end
+
+      it 'is to be generated Array[untyped]' do
+        assert_equal <<~TEXT, @outputs.add_method_definition(@setting)
+          module Settings
+            def self.uho: () -> Array[untyped]
+        TEXT
+      end
+    end
   end
 
   describe '#finalize' do


### PR DESCRIPTION
`settings.yml` like this:

```
# settings.yml
uho:
  - name: name1
    title: title1
    body: body1
  - name: name2
    title: title2
    body: body2
  - name: name3
    title: title3
    body: body3
```

The type definition of this generates `Array[Config::Options]`.

```
module Settings
  def self.uho: () -> Array[Config::Options]
end
```

But, we do not want to treat it as `Config::Options`, so simply set it to `untyped`.

```
module Settings
  def self.uho: () -> Array[untyped]
end
```

A possible use case in this case would be iterative processing such as `each`.

```ruby
Settings.uho.each do |setting|
  setting.name #=> "name1"
  setting.title #=> "title1"
  setting.body #=> "body1"
end
```

If so, there is little point in having these type definitions in the `Settings` module. There is a rationale for setting them to `untyped`.